### PR TITLE
feat: #10 add code and code block to the editor

### DIFF
--- a/packages/strapi-plugin-rich-text/admin/src/components/RichText/Components/BlockTypeSelect.tsx
+++ b/packages/strapi-plugin-rich-text/admin/src/components/RichText/Components/BlockTypeSelect.tsx
@@ -43,6 +43,9 @@ export default function BlockTypeSelect({ editor }: { editor: Editor }) {
       case "paragraph":
         editor.chain().focus().setParagraph().run();
         break;
+      case "codeBlock":
+        editor.chain().focus().toggleCodeBlock().run();
+        break;
     }
 
     setTimeout(() => {
@@ -59,6 +62,7 @@ export default function BlockTypeSelect({ editor }: { editor: Editor }) {
     if (editor.isActive("heading", { level: 6 })) setSelectedType("h6");
     if (editor.isActive("alert")) setSelectedType("alert");
     if (editor.isActive("paragraph")) setSelectedType("paragraph");
+    if (editor.isActive("codeBlock")) setSelectedType("codeBlock");
     if (editor.isActive("blockquote")) setSelectedType("blockquote");
     if (editor.isActive("orderedList")) setSelectedType("orderedList");
     if (editor.isActive("bulletList")) setSelectedType("bulletList");
@@ -122,6 +126,12 @@ export default function BlockTypeSelect({ editor }: { editor: Editor }) {
         {formatMessage({
           id: "rich-text.editor.toolbar.select.quote",
           defaultMessage: "Quote",
+        })}
+      </Option>
+      <Option value={"codeBlock"}>
+        {formatMessage({
+          id: "rich-text.editor.toolbar.select.code-block",
+          defaultMessage: "Code Block",
         })}
       </Option>
       <Option value={"orderedList"}>

--- a/packages/strapi-plugin-rich-text/admin/src/components/RichText/Editor.styles.tsx
+++ b/packages/strapi-plugin-rich-text/admin/src/components/RichText/Editor.styles.tsx
@@ -136,9 +136,16 @@ export const StyledEditor = styled("div")`
       text-decoration-skip-ink: none;
     }
 
+    code {
+      background: ${({ theme }) => theme.colors.neutral100};
+      font-family: monospace;
+      font-size: 0.8rem;
+      padding: 0.25rem 0.5rem;
+    }
+
     pre {
-      background: #0d0d0d;
-      color: #fff;
+      background: ${({ theme }) => theme.colors.neutral1000};
+      color: ${({ theme }) => theme.colors.neutral0};
       font-family: monospace;
       padding: 0.75rem 1rem;
       border-radius: 0.5rem;

--- a/packages/strapi-plugin-rich-text/admin/src/components/RichText/Editor.tsx
+++ b/packages/strapi-plugin-rich-text/admin/src/components/RichText/Editor.tsx
@@ -4,7 +4,7 @@ import { Bold } from "@tiptap/extension-bold";
 import { BulletList } from "@tiptap/extension-bullet-list";
 import { CharacterCount } from "@tiptap/extension-character-count";
 import { Code } from "@tiptap/extension-code";
-import { CodeBlock } from "@tiptap/extension-code-block";
+import { CodeBlockLowlight } from "@tiptap/extension-code-block-lowlight";
 import { Color } from "@tiptap/extension-color";
 import { Highlight } from "@tiptap/extension-highlight";
 import { Document } from "@tiptap/extension-document";
@@ -41,8 +41,11 @@ import { StyledEditor } from "./Editor.styles";
 import Toolbar from "./Toolbar";
 
 import Alert from "../../extensions/extension-alert/src";
+import { common, createLowlight } from "lowlight";
 
 const limit = undefined;
+
+const lowlight = createLowlight(common);
 
 const extensions: (Extension | Node | Mark)[] = [
   Abbr,
@@ -55,7 +58,9 @@ const extensions: (Extension | Node | Mark)[] = [
     limit,
   }),
   Code,
-  CodeBlock,
+  CodeBlockLowlight.configure({
+    lowlight,
+  }),
   Color,
   Document,
   Dropcursor,

--- a/packages/strapi-plugin-rich-text/admin/src/components/RichText/Toolbar.tsx
+++ b/packages/strapi-plugin-rich-text/admin/src/components/RichText/Toolbar.tsx
@@ -7,6 +7,7 @@ import {
   ArrowLeft,
   ArrowRight,
   Bold,
+  Code,
   Italic,
   Link,
   Minus,
@@ -97,6 +98,16 @@ export default function Toolbar({ editor }: ToolbarProps) {
                   onClick={() => editor.chain().focus().toggleStrike().run()}
                   disabled={!editor.can().chain().focus().toggleStrike().run()}
                   className={editor.isActive("strike") ? "is-active" : ""}
+                />
+                <IconButton
+                  icon={<Code />}
+                  label={formatMessage({
+                    id: "rich-text.editor.toolbar.button.code",
+                    defaultMessage: "Code",
+                  })}
+                  onClick={() => editor.chain().focus().toggleCode().run()}
+                  disabled={!editor.can().chain().focus().toggleCode().run()}
+                  className={editor.isActive("code") ? "is-active" : ""}
                 />
                 <IconButton
                   ref={colorSourceRef}

--- a/packages/strapi-plugin-rich-text/admin/src/translations/en.json
+++ b/packages/strapi-plugin-rich-text/admin/src/translations/en.json
@@ -11,6 +11,7 @@
   "editor.toolbar.button.abbreviation": "Abbreviation",
   "editor.toolbar.button.bold": "Bold",
   "editor.toolbar.button.color": "Color",
+  "editor.toolbar.button.code": "Code",
   "editor.toolbar.button.highlight": "Highlight",
   "editor.toolbar.button.italic": "Italic",
   "editor.toolbar.button.underline": "Underline",

--- a/packages/strapi-plugin-rich-text/admin/src/translations/en.json
+++ b/packages/strapi-plugin-rich-text/admin/src/translations/en.json
@@ -37,6 +37,7 @@
   "editor.toolbar.select.heading-4": "Heading 4",
   "editor.toolbar.select.heading-5": "Heading 5",
   "editor.toolbar.select.heading-6": "Heading 6",
+  "editor.toolbar.select.code-block": "Code Block",
   "editor.toolbar.select.quote": "Quote",
   "editor.toolbar.select.ordered-list": "Ordered List",
   "editor.toolbar.select.bullet-list": "Bullet List",

--- a/packages/strapi-plugin-rich-text/admin/src/translations/es.json
+++ b/packages/strapi-plugin-rich-text/admin/src/translations/es.json
@@ -11,6 +11,7 @@
   "editor.toolbar.button.abbreviation": "Abreviatura",
   "editor.toolbar.button.bold": "Negrita",
   "editor.toolbar.button.color": "Color",
+  "editor.toolbar.button.code": "Código",
   "editor.toolbar.button.highlight": "Resaltar",
   "editor.toolbar.button.italic": "Cursiva",
   "editor.toolbar.button.underline": "Subrayado",

--- a/packages/strapi-plugin-rich-text/admin/src/translations/es.json
+++ b/packages/strapi-plugin-rich-text/admin/src/translations/es.json
@@ -37,6 +37,7 @@
   "editor.toolbar.select.heading-4": "Encabezado 4",
   "editor.toolbar.select.heading-5": "Encabezado 5",
   "editor.toolbar.select.heading-6": "Encabezado 6",
+  "editor.toolbar.select.code-block": "Bloque de Código",
   "editor.toolbar.select.quote": "Cita",
   "editor.toolbar.select.ordered-list": "Lista Ordenada",
   "editor.toolbar.select.bullet-list": "Lista de Viñetas",

--- a/packages/strapi-plugin-rich-text/admin/src/translations/tr.json
+++ b/packages/strapi-plugin-rich-text/admin/src/translations/tr.json
@@ -37,6 +37,7 @@
   "editor.toolbar.select.heading-4": "Başlık 4",
   "editor.toolbar.select.heading-5": "Başlık 5",
   "editor.toolbar.select.heading-6": "Başlık 6",
+  "editor.toolbar.select.code-block": "Kod Bloğu",
   "editor.toolbar.select.quote": "Alıntı",
   "editor.toolbar.select.ordered-list": "Sıralı Liste",
   "editor.toolbar.select.bullet-list": "Madde İşaretli Liste",

--- a/packages/strapi-plugin-rich-text/admin/src/translations/tr.json
+++ b/packages/strapi-plugin-rich-text/admin/src/translations/tr.json
@@ -11,6 +11,7 @@
   "editor.toolbar.button.abbreviation": "Kısaltma",
   "editor.toolbar.button.bold": "Kalın",
   "editor.toolbar.button.color": "Renk",
+  "editor.toolbar.button.code": "Kod",
   "editor.toolbar.button.highlight": "Vurgula",
   "editor.toolbar.button.italic": "İtalik",
   "editor.toolbar.button.underline": "Altı çizili",

--- a/packages/strapi-plugin-rich-text/package.json
+++ b/packages/strapi-plugin-rich-text/package.json
@@ -20,6 +20,7 @@
     "@tiptap/extension-character-count": "^2.1.13",
     "@tiptap/extension-code": "^2.1.13",
     "@tiptap/extension-code-block": "^2.1.13",
+    "@tiptap/extension-code-block-lowlight": "2.6.6",
     "@tiptap/extension-color": "2.6.4",
     "@tiptap/extension-document": "^2.1.13",
     "@tiptap/extension-dropcursor": "^2.1.13",
@@ -48,6 +49,7 @@
     "@tiptap/extension-youtube": "^2.1.13",
     "@tiptap/pm": "^2.1.13",
     "@tiptap/react": "^2.1.13",
+    "lowlight": "3.1.0",
     "markdown-it": "^14.0.0",
     "vanilla-colorful": "0.7.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       '@tiptap/extension-code-block':
         specifier: ^2.1.13
         version: 2.1.13(@tiptap/core@2.1.13(@tiptap/pm@2.1.13))(@tiptap/pm@2.1.13)
+      '@tiptap/extension-code-block-lowlight':
+        specifier: 2.6.6
+        version: 2.6.6(@tiptap/core@2.1.13(@tiptap/pm@2.1.13))(@tiptap/extension-code-block@2.1.13(@tiptap/core@2.1.13(@tiptap/pm@2.1.13))(@tiptap/pm@2.1.13))(@tiptap/pm@2.1.13)(highlight.js@11.9.0)(lowlight@3.1.0)
       '@tiptap/extension-color':
         specifier: 2.6.4
         version: 2.6.4(@tiptap/core@2.1.13(@tiptap/pm@2.1.13))(@tiptap/extension-text-style@2.6.4(@tiptap/core@2.1.13(@tiptap/pm@2.1.13)))
@@ -210,6 +213,9 @@ importers:
       '@tiptap/react':
         specifier: ^2.1.13
         version: 2.1.13(@tiptap/core@2.1.13(@tiptap/pm@2.1.13))(@tiptap/pm@2.1.13)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      lowlight:
+        specifier: 3.1.0
+        version: 3.1.0
       markdown-it:
         specifier: ^14.0.0
         version: 14.0.0
@@ -2431,6 +2437,15 @@ packages:
       '@tiptap/core': ^2.0.0
       '@tiptap/pm': ^2.0.0
 
+  '@tiptap/extension-code-block-lowlight@2.6.6':
+    resolution: {integrity: sha512-GXzuQGKxxOmozzvwBEKdEnX1fv9R8qt9Q4Q+j3Itc+um7nYNKHDT1xNIk1BQUeu8Mr6fQVFgCu3FDybsRp9Ncw==}
+    peerDependencies:
+      '@tiptap/core': ^2.6.6
+      '@tiptap/extension-code-block': ^2.6.6
+      '@tiptap/pm': ^2.6.6
+      highlight.js: ^11
+      lowlight: ^2 || ^3
+
   '@tiptap/extension-code-block@2.1.13':
     resolution: {integrity: sha512-E3tweNExPOV+t1ODKX0MDVsS0aeHGWc1ECt+uyp6XwzsN0bdF2A5+pttQqM7sTcMnQkVACGFbn9wDeLRRcfyQg==}
     peerDependencies:
@@ -2639,6 +2654,9 @@ packages:
   '@types/glob@7.2.0':
     resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
 
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
   '@types/history@4.7.11':
     resolution: {integrity: sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==}
 
@@ -2761,6 +2779,9 @@ packages:
 
   '@types/triple-beam@1.3.5':
     resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@types/use-sync-external-store@0.0.3':
     resolution: {integrity: sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==}
@@ -3937,6 +3958,9 @@ packages:
   detect-node@2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
 
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
@@ -4862,6 +4886,10 @@ packages:
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
+  highlight.js@11.9.0:
+    resolution: {integrity: sha512-fJ7cW7fQGCYAkgv4CPfwFHrfd/cLS4Hau96JuJ+ZTOWhjnhoeN1ub1tFmALm/+lW5z4WCAuAV9bm05AP0mS6Gw==}
+    engines: {node: '>=12.0.0'}
+
   history@4.10.1:
     resolution: {integrity: sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==}
 
@@ -5765,6 +5793,9 @@ packages:
   lowercase-keys@2.0.0:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
     engines: {node: '>=8'}
+
+  lowlight@3.1.0:
+    resolution: {integrity: sha512-CEbNVoSikAxwDMDPjXlqlFYiZLkDJHwyGu/MfOsJnF3d7f3tds5J3z8s/l9TMXhzfsJCCJEAsD78842mwmg0PQ==}
 
   lru-cache@10.1.0:
     resolution: {integrity: sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==}
@@ -11720,6 +11751,14 @@ snapshots:
       '@tiptap/core': 2.1.13(@tiptap/pm@2.1.13)
       '@tiptap/pm': 2.1.13
 
+  '@tiptap/extension-code-block-lowlight@2.6.6(@tiptap/core@2.1.13(@tiptap/pm@2.1.13))(@tiptap/extension-code-block@2.1.13(@tiptap/core@2.1.13(@tiptap/pm@2.1.13))(@tiptap/pm@2.1.13))(@tiptap/pm@2.1.13)(highlight.js@11.9.0)(lowlight@3.1.0)':
+    dependencies:
+      '@tiptap/core': 2.1.13(@tiptap/pm@2.1.13)
+      '@tiptap/extension-code-block': 2.1.13(@tiptap/core@2.1.13(@tiptap/pm@2.1.13))(@tiptap/pm@2.1.13)
+      '@tiptap/pm': 2.1.13
+      highlight.js: 11.9.0
+      lowlight: 3.1.0
+
   '@tiptap/extension-code-block@2.1.13(@tiptap/core@2.1.13(@tiptap/pm@2.1.13))(@tiptap/pm@2.1.13)':
     dependencies:
       '@tiptap/core': 2.1.13(@tiptap/pm@2.1.13)
@@ -11949,6 +11988,10 @@ snapshots:
       '@types/minimatch': 5.1.2
       '@types/node': 20.10.1
 
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/history@4.7.11': {}
 
   '@types/hoist-non-react-statics@3.3.5':
@@ -12081,6 +12124,8 @@ snapshots:
       '@types/node': 20.10.1
 
   '@types/triple-beam@1.3.5': {}
+
+  '@types/unist@3.0.3': {}
 
   '@types/use-sync-external-store@0.0.3': {}
 
@@ -13440,6 +13485,10 @@ snapshots:
 
   detect-node@2.1.0: {}
 
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
+
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
@@ -14740,6 +14789,8 @@ snapshots:
 
   highlight.js@10.7.3: {}
 
+  highlight.js@11.9.0: {}
+
   history@4.10.1:
     dependencies:
       '@babel/runtime': 7.23.2
@@ -15705,6 +15756,12 @@ snapshots:
       tslib: 2.6.2
 
   lowercase-keys@2.0.0: {}
+
+  lowlight@3.1.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      devlop: 1.1.0
+      highlight.js: 11.9.0
 
   lru-cache@10.1.0: {}
 


### PR DESCRIPTION
### What does it do?

It adds the Tiptap's code and code block lowlight extensions to the editor, code block to block type selector, and code to the toolbar.

### Why is it needed?
Many developers want to add code to their blogs, which these plugins allow.

### How to test it?
For code: either select a text and click on the button, or use backtick (`) to ope and close the text code.

[For code block](https://tiptap.dev/docs/editor/extensions/nodes/code-block-lowlight): either select the paragraph to transform and choose code block from the block selector, or use three backtick (```) to open and close the code block, you can add the language short name after the opening three backticks to specify the language.

![Screenshot_20240831_153420](https://github.com/user-attachments/assets/b11cc146-be18-4cf9-9bc1-54083278e875)


### Notes

- It requires merging the following [PR above](https://github.com/konstantinmuenster/strapi-plugin-rich-text/pull/20).
